### PR TITLE
Regex fixes

### DIFF
--- a/biblescrapeway/reference.py
+++ b/biblescrapeway/reference.py
@@ -50,16 +50,16 @@ def _get_normalized_book_name(string):
     """
     _string = string.strip()
     for regex in book_regex:
-        if re.match(regex[0] + "[A-Za-z\. _]*$", _string):
+        if re.match(regex[0] + "[A-Za-z. _]*$", _string):
             return regex[1]
     raise ReferenceError("Cannot find book `{}`".format(_string))
 
 class Reference:
     """A bible reference to either a chapter or verse
     """
-    BCV_regex = re.compile("^([0-9]?[ _\.]?[A-Za-z]+|[A-Za-z][A-Za-z\._ ]*[A-Za-z])[\._ ]*([0-9]+)[\.: _]?([0-9]*)$")
-    CV_regex = re.compile("^([0-9]+)[\.: ]([0-9]+)$")
-    V_regex = re.compile("^([0-9]+)$")
+    BCV_regex = re.compile(r"^([0-9]?[ _.]?[A-Za-z]+|[A-Za-z][A-Za-z._ ]*[A-Za-z])[._ ]*([0-9]+)[.: _]?([0-9]*)$")
+    CV_regex = re.compile(r"^([0-9]+)[.: ]([0-9]+)$")
+    V_regex = re.compile(r"^([0-9]+)$")
 
     def __init__(self, book, chapter, verse = None):
         self.book = _get_normalized_book_name(book)

--- a/biblescrapeway/scraper.py
+++ b/biblescrapeway/scraper.py
@@ -171,7 +171,7 @@ def scrape(ref_string_or_obj, version="ESV"):
     verse_ids = dict()
     for node in sc.find_all(class_="text"):
         for clsstr in node.attrs['class']:
-            if re.match("[A-Za-z0-9]+[-]\d+[-]\d+",clsstr):
+            if re.match(r"[A-Za-z0-9]+-\d+-\d+", clsstr):
                 vv = int(clsstr.split("-")[-1])
                 verse_ids[vv] = clsstr
 


### PR DESCRIPTION
When you fire up an app using this, you get these lovely messages:

```
/usr/local/lib/python3.13/site-packages/biblescrapeway/scraper.py:174: SyntaxWarning: invalid escape sequence '\d'
  if re.match("[A-Za-z0-9]+[-]\d+[-]\d+",clsstr):
/usr/local/lib/python3.13/site-packages/biblescrapeway/reference.py:53: SyntaxWarning: invalid escape sequence '\.'
  if re.match(regex[0] + "[A-Za-z\. _]*$", _string):
/usr/local/lib/python3.13/site-packages/biblescrapeway/reference.py:60: SyntaxWarning: invalid escape sequence '\.'
  BCV_regex = re.compile("^([0-9]?[ _\.]?[A-Za-z]+|[A-Za-z][A-Za-z\._ ]*[A-Za-z])[\._ ]*([0-9]+)[\.: _]?([0-9]*)$")
/usr/local/lib/python3.13/site-packages/biblescrapeway/reference.py:61: SyntaxWarning: invalid escape sequence '\.'
  CV_regex = re.compile("^([0-9]+)[\.: ]([0-9]+)$")
  ```
  
  Small PR adding `r` so that Python knows that it's regex, and also removed unnecessary escape sequence characters.